### PR TITLE
[p.140]fix typo

### DIFF
--- a/src/ejsicp.tex
+++ b/src/ejsicp.tex
@@ -12412,7 +12412,7 @@ Define a procedure \code{split} with the property that evaluating
 produces procedures \code{right\-/split} and \code{up\-/split} with the same
 behaviors as the ones already defined.
 
-既に定義住みのものと全く同じ振舞を行う手続\code{right\-/split}と\code{up\-/split}を
+既に定義済みのものと全く同じ振舞を行う手続\code{right\-/split}と\code{up\-/split}を
 生成するよう定義せよ。
 \end{quote}
 

--- a/src/jsicp.tex
+++ b/src/jsicp.tex
@@ -8429,7 +8429,7 @@ from the \code{wave} painter of \link{Figure 2.10}.
 \end{scheme}
 
 \noindent
-既に定義住みのものと全く同じ振舞を行う手続\code{right\-/split}と\code{up\-/split}を
+既に定義済みのものと全く同じ振舞を行う手続\code{right\-/split}と\code{up\-/split}を
 生成するよう定義せよ。
 \end{quote}
 


### PR DESCRIPTION
Hi, I correct word "定義住み" to ”定義済み” at page 140.

Thanks.
